### PR TITLE
Save Schematic Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Welcome to Schematica!
 Planned future additions:
 - Add compatibility with the Lord of the Rings mod (fix a few edge cases with the printer)
-- Adding the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script (Possibly, as disabling the printer can also be done server side)
+- Add the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script
 
 Changes from Original:
 - Store Coordinates per world/server. No more re-entering coordinates for large builds!
@@ -122,4 +122,4 @@ Crashing? Have a suggestion? Found a bug? Create an issue now!
         * Detailed description of the bug
 5. Click `Submit new issue`, and wait for feedback!
 
-Partially based off this README off [pahimar's version](https://github.com/pahimar/Equivalent-Exchange-3).
+Shamelessly based off this README off [pahimar's version](https://github.com/pahimar/Equivalent-Exchange-3).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Welcome to Schematica!
 Fork of Schematica, based of the GTNH fork.
 This fork is intended for the following things:
-- Adding the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script
-- Add an option to store coordinates of schematics per world/server
+- Adding the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script (Possibly, as disabling the printer can also be done server side)
+- Add an option to store coordinates of schematics per world/server (Main goal)
 - Add compatibility with the Lord of the Rings mod (fix a few edge cases with the printer)
 - Update the README as it still refers to Jdk 7, among other things
 After the following changes have been made I will submit a pull request, if it's accepted these changes will be merged into the GTNH fork of Schematica. Otherwise, I'll host this version elsewhere (Probably Github, maybe Modrinth)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 ## Welcome to Schematica!
+Fork of Schematica, based of the GTNH fork.
+This fork is intended for the following things:
+- Adding the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script
+- Add an option to store coordinates of schematics per world/server
+- Add compatibility with the Lord of the Rings mod (fix a few edge cases with the printer)
+- Update the README as it still refers to Jdk 7, among other things
+After the following changes have been made I will submit a pull request, if it's accepted these changes will be merged into the GTNH fork of Schematica. Otherwise, I'll host this version elsewhere (Probably Github, maybe Modrinth)
+
 [Compiling Schematica](#compile-schematica) - for those that want the latest unreleased features
 
 [Contributing](#contributing) - for those that want to help out
@@ -18,19 +26,14 @@
 The Java JDK is used to compile Schematica.
 
 1. Download and install the Java JDK.
-    * [Windows/Mac download link](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html). Scroll down, accept the `Oracle Binary Code License Agreement for Java SE`, and download it (if you have a 64-bit OS, please download the 64-bit version).
-    * Linux: Installation methods for certain popular flavors of Linux are listed below. If your distribution is not listed, follow the instructions specific to your package manager or install it manually [here](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html).
-        * Gentoo: `emerge dev-java/oracle-jdk-bin`
-        * Archlinux: `pacman -S jdk7-openjdk`
-        * Ubuntu/Debian: `apt-get install openjdk-7-jdk`
-        * Fedora: `yum install java-1.7.0-openjdk`
+    * [Download link](https://adoptium.net/temurin/releases/?version=8). Select the appropriate version for your OS
 2. Set up the environment.
     * Windows: Set environment variables for the JDK.
         1. Go to `Control Panel\System and Security\System`, and click on `Advanced System Settings` on the left-hand side.
         2. Click on `Environment Variables`.
         3. Under `System Variables`, click `New`.
         4. For `Variable Name`, input `JAVA_HOME`.
-        5. For `Variable Value`, input something similar to `C:\Program Files\Java\jdk1.7.0_45` exactly as shown (or wherever your Java JDK installation is), and click `Ok`.
+        5. For `Variable Value`, input something similar to `C:\Program Files\Java\8u332` exactly as shown (or wherever your Java JDK installation is), and click `Ok`.
         6. Scroll down to a variable named `Path`, and double-click on it.
         7. Append `;%JAVA_HOME%\bin` EXACTLY AS SHOWN and click `Ok`. Make sure the location is correct; double-check just to make sure.
 3. Open up your command line and run `javac`. If it spews out a bunch of possible options and the usage, then you're good to go. If not try the steps again.
@@ -42,6 +45,11 @@ Git is used to clone Schematica and update your local copy.
 2. *Optional* Download and install a Git GUI client, such as Github for Windows/Mac, SmartGitHg, TortoiseGit, etc. A nice list is available [here](http://git-scm.com/downloads/guis).
 
 #### Setup Schematica
+
+##### IntelliJ
+Import this repository. or, if you're planning modifications, a fork. IntelliJ will automatically execute the `gradlew setupDevWorkspace` task. After that there's a high chance the following error is thrown: `Could not find :forgeBin:1.7.10-10.13.4.1614-1.7.10.` or something similar. If that happens, execute `./gradlew setupDecompWorkspace` in your terminal. After this refresh gradle, and you should be ready to go.
+
+##### Command line
 This section assumes that you're using the command-line version of Git.
 
 1. Open up your command line.
@@ -56,6 +64,8 @@ This section assumes that you're using the command-line version of Git.
 ***
 
 #### Compile Schematica
+
+If you use IntelliJ IDEA you can skip step one
 1. Execute `gradlew setupDevWorkspace`. This sets up Forge and downloads the necessary libraries to build Schematica. This might take some time, be patient.
     * You will generally only have to do this once until the Forge version in `build.properties` changes.
 2. Execute `gradlew build`. If you did everything right, `BUILD SUCCESSFUL` will be displayed after it finishes. This should be relatively quick.
@@ -97,7 +107,7 @@ When you finish up your PR you'll want to [squash](http://davidwalsh.name/squash
 2. Execute `git rebase -i HEAD~X` where `X` is the amount of your commits. This will make sure you squash only your own commits.
 3. You should now see a list of all your commits, prefixed with `pick`. Change all instances of `pick` (excluding the first!) into `squash` or simply `s`. Then save/quit the editor once.
 4. A second screen should show up, displaying all the commit messages (you may edit them, delete or add some). After your done save/quit the editor again.
-5. If git successfuly rebased things simply push your cleaned up commits by executing `git push -f`.
+5. If git successfully rebased things simply push your cleaned up commits by executing `git push -f`.
 
 #### Creating an Issue
 Crashing? Have a suggestion? Found a bug? Create an issue now!
@@ -112,4 +122,4 @@ Crashing? Have a suggestion? Found a bug? Create an issue now!
         * Detailed description of the bug
 5. Click `Submit new issue`, and wait for feedback!
 
-Shamelessly based this README off [pahimar's version](https://github.com/pahimar/Equivalent-Exchange-3).
+Partially based off this README off [pahimar's version](https://github.com/pahimar/Equivalent-Exchange-3).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ## Welcome to Schematica!
-Fork of Schematica, based of the GTNH fork.
-This fork is intended for the following things:
-- Adding the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script (Possibly, as disabling the printer can also be done server side)
-- Add an option to store coordinates of schematics per world/server (Main goal)
+Planned future additions:
 - Add compatibility with the Lord of the Rings mod (fix a few edge cases with the printer)
-- Update the README as it still refers to Jdk 7, among other things
-After the following changes have been made I will submit a pull request, if it's accepted these changes will be merged into the GTNH fork of Schematica. Otherwise, I'll host this version elsewhere (Probably Github, maybe Modrinth)
+- Adding the [Fairplay mode](https://www.planetminecraft.com/mod/schematica-fairplay/) to the base build script (Possibly, as disabling the printer can also be done server side)
+
+Changes from Original:
+- Store Coordinates per world/server. No more re-entering coordinates for large builds!
+- README update
 
 [Compiling Schematica](#compile-schematica) - for those that want the latest unreleased features
 

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
@@ -21,6 +21,30 @@ import static com.github.lunatrius.schematica.client.util.WorldServerName.worldS
 public class GuiSchematicControl extends GuiScreenBase {
     private final SchematicWorld schematic;
     private final SchematicPrinter printer;
+
+    private int centerX = 0;
+    private int centerY = 0;
+
+    private GuiNumericField numericX = null;
+    private GuiNumericField numericY = null;
+    private GuiNumericField numericZ = null;
+
+    private GuiButton btnUnload = null;
+    private GuiButton btnLayerMode = null;
+    private GuiNumericField nfLayer = null;
+
+    private GuiButton btnHide = null;
+    private GuiButton btnMove = null;
+    private GuiButton btnFlip = null;
+    private GuiButton btnRotate = null;
+
+    private GuiButton btnMaterials = null;
+    private GuiButton btnPrint = null;
+
+    private GuiButton btnSaveCoordinates = null;
+
+    private final String strSaveCoordinatesSuccess = I18n.format(Names.Chat.SAVE_COORDINATES_SUCCESS);
+    private final String strSaveCoordinatesFail = I18n.format(Names.Chat.SAVE_COORDINATES_FAIL);
     private final String strSaveCoordinates = I18n.format(Names.Gui.Control.SAVE_COORDINATES);
     private final String strMoveSchematic = I18n.format(Names.Gui.Control.MOVE_SCHEMATIC);
     private final String strOperations = I18n.format(Names.Gui.Control.OPERATIONS);
@@ -36,23 +60,6 @@ public class GuiSchematicControl extends GuiScreenBase {
     private final String strZ = I18n.format(Names.Gui.Z);
     private final String strOn = I18n.format(Names.Gui.ON);
     private final String strOff = I18n.format(Names.Gui.OFF);
-    private final String strSaveCoordinatesSuccess = I18n.format(Names.Chat.SAVE_COORDINATES_SUCCESS);
-    private final String strSaveCoordinatesFail = I18n.format(Names.Chat.SAVE_COORDINATES_FAIL);
-    private int centerX = 0;
-    private int centerY = 0;
-    private GuiNumericField numericX = null;
-    private GuiNumericField numericY = null;
-    private GuiNumericField numericZ = null;
-    private GuiButton btnUnload = null;
-    private GuiButton btnLayerMode = null;
-    private GuiNumericField nfLayer = null;
-    private GuiButton btnHide = null;
-    private GuiButton btnMove = null;
-    private GuiButton btnFlip = null;
-    private GuiButton btnRotate = null;
-    private GuiButton btnMaterials = null;
-    private GuiButton btnPrint = null;
-    private GuiButton btnSaveCoordinates = null;
 
     public GuiSchematicControl(GuiScreen guiScreen) {
         super(guiScreen);

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
@@ -10,6 +10,8 @@ import com.github.lunatrius.schematica.client.world.SchematicWorld;
 import com.github.lunatrius.schematica.proxy.ClientProxy;
 import com.github.lunatrius.schematica.reference.Constants;
 import com.github.lunatrius.schematica.reference.Names;
+import com.github.lunatrius.schematica.reference.Reference;
+import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
@@ -17,28 +19,6 @@ import net.minecraft.client.resources.I18n;
 public class GuiSchematicControl extends GuiScreenBase {
     private final SchematicWorld schematic;
     private final SchematicPrinter printer;
-
-    private int centerX = 0;
-    private int centerY = 0;
-
-    private GuiNumericField numericX = null;
-    private GuiNumericField numericY = null;
-    private GuiNumericField numericZ = null;
-
-    private GuiButton btnUnload = null;
-    private GuiButton btnLayerMode = null;
-    private GuiNumericField nfLayer = null;
-
-    private GuiButton btnHide = null;
-    private GuiButton btnMove = null;
-    private GuiButton btnFlip = null;
-    private GuiButton btnRotate = null;
-
-    private GuiButton btnMaterials = null;
-    private GuiButton btnPrint = null;
-
-    private GuiButton btnSaveCoordinates = null;
-
     private final String strSaveCoordinates = I18n.format(Names.Gui.Control.SAVE_COORDINATES);
     private final String strMoveSchematic = I18n.format(Names.Gui.Control.MOVE_SCHEMATIC);
     private final String strOperations = I18n.format(Names.Gui.Control.OPERATIONS);
@@ -54,6 +34,21 @@ public class GuiSchematicControl extends GuiScreenBase {
     private final String strZ = I18n.format(Names.Gui.Z);
     private final String strOn = I18n.format(Names.Gui.ON);
     private final String strOff = I18n.format(Names.Gui.OFF);
+    private int centerX = 0;
+    private int centerY = 0;
+    private GuiNumericField numericX = null;
+    private GuiNumericField numericY = null;
+    private GuiNumericField numericZ = null;
+    private GuiButton btnUnload = null;
+    private GuiButton btnLayerMode = null;
+    private GuiNumericField nfLayer = null;
+    private GuiButton btnHide = null;
+    private GuiButton btnMove = null;
+    private GuiButton btnFlip = null;
+    private GuiButton btnRotate = null;
+    private GuiButton btnMaterials = null;
+    private GuiButton btnPrint = null;
+    private GuiButton btnSaveCoordinates = null;
 
     public GuiSchematicControl(GuiScreen guiScreen) {
         super(guiScreen);
@@ -199,6 +194,16 @@ public class GuiSchematicControl extends GuiScreenBase {
             } else if (guiButton.id == this.btnPrint.id && this.printer.isEnabled()) {
                 boolean isPrinting = this.printer.togglePrinting();
                 this.btnPrint.displayString = isPrinting ? this.strOn : this.strOff;
+            } else if (guiButton.id == this.btnSaveCoordinates.id) {
+                //Goal one, print the info we're gonna store: name of world/server in servers.dat, name of schematic, coordinates
+                String WorldOrServerName;
+                if (this.mc.isSingleplayer()) {
+                    WorldOrServerName = FMLCommonHandler.instance().getMinecraftServerInstance().getWorldName();
+                } else {
+                    //Gets the server data, only works if you're playing on a server. if you're using direct connect the name will be "Minecraft Server". Crashes if singleplayer
+                    WorldOrServerName = this.mc.func_147104_D().serverName;
+                }
+                Reference.logger.info("Saved coordinates, stored data:\nCoordinates: {} {} {}\nSchematic Name: {}\nWorld Name/server Name: {}",this.numericX.getValue(),this.numericY.getValue(),this.numericZ.getValue(),this.schematic.name,WorldOrServerName);
             }
         }
     }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/control/GuiSchematicControl.java
@@ -37,6 +37,9 @@ public class GuiSchematicControl extends GuiScreenBase {
     private GuiButton btnMaterials = null;
     private GuiButton btnPrint = null;
 
+    private GuiButton btnSaveCoordinates = null;
+
+    private final String strSaveCoordinates = I18n.format(Names.Gui.Control.SAVE_COORDINATES);
     private final String strMoveSchematic = I18n.format(Names.Gui.Control.MOVE_SCHEMATIC);
     private final String strOperations = I18n.format(Names.Gui.Control.OPERATIONS);
     private final String strUnload = I18n.format(Names.Gui.Control.UNLOAD);
@@ -103,6 +106,9 @@ public class GuiSchematicControl extends GuiScreenBase {
         this.btnPrint = new GuiButton(id++, 10, this.height - 30, 80, 20, this.printer.isPrinting() ? this.strOn : this.strOff);
         this.buttonList.add(this.btnPrint);
 
+        this.btnSaveCoordinates = new GuiButton(id++, this.centerX - 50, this.height - 200, 100, 20, this.strSaveCoordinates);
+        this.buttonList.add(this.btnSaveCoordinates);
+
         this.numericX.setEnabled(this.schematic != null);
         this.numericY.setEnabled(this.schematic != null);
         this.numericZ.setEnabled(this.schematic != null);
@@ -118,6 +124,8 @@ public class GuiSchematicControl extends GuiScreenBase {
         this.btnRotate.enabled = this.schematic != null;
         this.btnMaterials.enabled = this.schematic != null;
         this.btnPrint.enabled = this.schematic != null && this.printer.isEnabled();
+
+        this.btnSaveCoordinates.enabled = this.schematic != null;
 
         setMinMax(this.numericX);
         setMinMax(this.numericY);

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoad.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoad.java
@@ -15,6 +15,8 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.lwjgl.Sys;
 
 import java.io.File;
@@ -22,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import static com.github.lunatrius.schematica.client.util.WorldServerName.worldServerName;
 
 public class GuiSchematicLoad extends GuiScreenBase {
     private static final FileFilterSchematic FILE_FILTER_FOLDER = new FileFilterSchematic(true);
@@ -157,8 +160,12 @@ public class GuiSchematicLoad extends GuiScreenBase {
                 if (Schematica.proxy.loadSchematic(null, this.currentDirectory, schematicEntry.getName())) {
                     SchematicWorld schematic = ClientProxy.schematic;
                     if (schematic != null) {
-                        ClientProxy.moveSchematicToPlayer(schematic);
-                        //TODO: Look up stored coordinates and load these instead
+                        ImmutablePair<Boolean, ImmutableTriple<Integer, Integer, Integer>> schematicCoordinate = ClientProxy.getCoordinates(worldServerName(this.mc), schematic.name);
+                        if (schematicCoordinate.left) {
+                            ClientProxy.moveSchematic(schematic, schematicCoordinate.right.left, schematicCoordinate.right.middle, schematicCoordinate.right.right);
+                        } else {
+                            ClientProxy.moveSchematicToPlayer(schematic);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoad.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/gui/load/GuiSchematicLoad.java
@@ -26,17 +26,13 @@ import java.util.List;
 public class GuiSchematicLoad extends GuiScreenBase {
     private static final FileFilterSchematic FILE_FILTER_FOLDER = new FileFilterSchematic(true);
     private static final FileFilterSchematic FILE_FILTER_SCHEMATIC = new FileFilterSchematic(false);
-
-    private GuiSchematicLoadSlot guiSchematicLoadSlot;
-
-    private GuiButton btnOpenDir = null;
-    private GuiButton btnDone = null;
-
+    protected final List<GuiSchematicEntry> schematicFiles = new ArrayList<GuiSchematicEntry>();
     private final String strTitle = I18n.format(Names.Gui.Load.TITLE);
     private final String strFolderInfo = I18n.format(Names.Gui.Load.FOLDER_INFO);
-
     protected File currentDirectory = ConfigurationHandler.schematicDirectory;
-    protected final List<GuiSchematicEntry> schematicFiles = new ArrayList<GuiSchematicEntry>();
+    private GuiSchematicLoadSlot guiSchematicLoadSlot;
+    private GuiButton btnOpenDir = null;
+    private GuiButton btnDone = null;
 
     public GuiSchematicLoad(GuiScreen guiScreen) {
         super(guiScreen);
@@ -114,7 +110,8 @@ public class GuiSchematicLoad extends GuiScreenBase {
         this.schematicFiles.clear();
 
         try {
-            if (!this.currentDirectory.getCanonicalPath().equals(ConfigurationHandler.schematicDirectory.getCanonicalPath())) {
+            if (!this.currentDirectory.getCanonicalPath()
+                .equals(ConfigurationHandler.schematicDirectory.getCanonicalPath())) {
                 this.schematicFiles.add(new GuiSchematicEntry("..", Items.lava_bucket, 0, true));
             }
         } catch (IOException e) {
@@ -161,6 +158,7 @@ public class GuiSchematicLoad extends GuiScreenBase {
                     SchematicWorld schematic = ClientProxy.schematic;
                     if (schematic != null) {
                         ClientProxy.moveSchematicToPlayer(schematic);
+                        //TODO: Look up stored coordinates and load these instead
                     }
                 }
             }

--- a/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
@@ -277,6 +277,8 @@ public class SchematicPrinter {
             return true;
         }
 
+        //TODO: LOTR mod chisel, plates, weapon racks
+
         return false;
     }
 

--- a/src/main/java/com/github/lunatrius/schematica/client/util/WorldServerName.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/WorldServerName.java
@@ -1,0 +1,22 @@
+package com.github.lunatrius.schematica.client.util;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import net.minecraft.client.Minecraft;
+
+public class WorldServerName {
+    /**
+     * Gets the world name if in singleplayer, or the name in server list when in multiplayer
+     * @param mc {@link Minecraft}
+     * @return {@link String} world name or server name
+     */
+    public static String worldServerName(Minecraft mc) {
+        String WorldOrServerName;
+        if (mc.isSingleplayer()) {
+            WorldOrServerName = FMLCommonHandler.instance().getMinecraftServerInstance().getWorldName();
+        } else {
+            //Gets the server data, only works if you're playing on a server. if you're using direct connect the name will be "Minecraft Server". Crashes if singleplayer
+            WorldOrServerName = mc.func_147104_D().serverName;
+        }
+        return WorldOrServerName;
+    }
+}

--- a/src/main/java/com/github/lunatrius/schematica/client/world/SchematicWorld.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/world/SchematicWorld.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class SchematicWorld extends World {
     private static final WorldSettings WORLD_SETTINGS = new WorldSettings(0, WorldSettings.GameType.CREATIVE, false, false, WorldType.FLAT);
 
+    public String name = "";
     public static final ItemStack DEFAULT_ICON = new ItemStack(Blocks.grass);
 
     private ISchematic schematic;
@@ -49,6 +50,10 @@ public class SchematicWorld extends World {
         this.isRendering = false;
         this.isRenderingLayer = false;
         this.renderingLayer = 0;
+    }
+    public SchematicWorld(ISchematic schematic, String filename) {
+        this(schematic);
+        this.name = filename.replace(".schematic","");
     }
 
     @Override

--- a/src/main/java/com/github/lunatrius/schematica/proxy/ClientProxy.java
+++ b/src/main/java/com/github/lunatrius/schematica/proxy/ClientProxy.java
@@ -224,7 +224,7 @@ public class ClientProxy extends CommonProxy {
             return false;
         }
 
-        SchematicWorld world = new SchematicWorld(schematic);
+        SchematicWorld world = new SchematicWorld(schematic,filename);
 
         Reference.logger.debug("Loaded {} [w:{},h:{},l:{}]", filename, world.getWidth(), world.getHeight(), world.getLength());
 

--- a/src/main/java/com/github/lunatrius/schematica/proxy/ClientProxy.java
+++ b/src/main/java/com/github/lunatrius/schematica/proxy/ClientProxy.java
@@ -7,14 +7,13 @@ import com.github.lunatrius.schematica.client.printer.SchematicPrinter;
 import com.github.lunatrius.schematica.client.renderer.RendererSchematicGlobal;
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
 import com.github.lunatrius.schematica.handler.ConfigurationHandler;
-import com.github.lunatrius.schematica.handler.client.ChatEventHandler;
-import com.github.lunatrius.schematica.handler.client.InputHandler;
-import com.github.lunatrius.schematica.handler.client.OverlayHandler;
-import com.github.lunatrius.schematica.handler.client.RenderTickHandler;
-import com.github.lunatrius.schematica.handler.client.TickHandler;
-import com.github.lunatrius.schematica.handler.client.WorldHandler;
+import com.github.lunatrius.schematica.handler.client.*;
+import com.github.lunatrius.schematica.reference.Constants;
 import com.github.lunatrius.schematica.reference.Reference;
 import com.github.lunatrius.schematica.world.schematic.SchematicFormat;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import cpw.mods.fml.client.config.GuiConfigEntries;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -28,30 +27,31 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.common.util.ForgeDirection;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ClientProxy extends CommonProxy {
-    public static boolean isRenderingGuide = false;
-    public static boolean isPendingReset = false;
-
     public static final Vector3d playerPosition = new Vector3d();
-    public static ForgeDirection orientation = ForgeDirection.UNKNOWN;
-    public static int rotationRender = 0;
-
-    public static SchematicWorld schematic = null;
-
     public static final Vector3i pointA = new Vector3i();
     public static final Vector3i pointB = new Vector3i();
     public static final Vector3i pointMin = new Vector3i();
     public static final Vector3i pointMax = new Vector3i();
-
-    public static MovingObjectPosition movingObjectPosition = null;
-
     private static final Minecraft MINECRAFT = Minecraft.getMinecraft();
-
-    private SchematicWorld schematicWorld = null;
+    public static boolean isRenderingGuide = false;
+    public static boolean isPendingReset = false;
+    public static ForgeDirection orientation = ForgeDirection.UNKNOWN;
+    public static int rotationRender = 0;
+    public static SchematicWorld schematic = null;
+    public static MovingObjectPosition movingObjectPosition = null;
+    private final SchematicWorld schematicWorld = null;
 
     public static void setPlayerData(EntityPlayer player, float partialTicks) {
         playerPosition.x = player.lastTickPosX + (player.posX - player.lastTickPosX) * partialTicks;
@@ -70,14 +70,14 @@ public class ClientProxy extends CommonProxy {
             return ForgeDirection.UP;
         } else {
             switch (MathHelper.floor_double(player.rotationYaw / 90.0 + 0.5) & 3) {
-            case 0:
-                return ForgeDirection.SOUTH;
-            case 1:
-                return ForgeDirection.WEST;
-            case 2:
-                return ForgeDirection.NORTH;
-            case 3:
-                return ForgeDirection.EAST;
+                case 0:
+                    return ForgeDirection.SOUTH;
+                case 1:
+                    return ForgeDirection.WEST;
+                case 2:
+                    return ForgeDirection.NORTH;
+                case 3:
+                    return ForgeDirection.EAST;
             }
         }
 
@@ -100,22 +100,22 @@ public class ClientProxy extends CommonProxy {
         point.z = (int) Math.floor(playerPosition.z);
 
         switch (rotationRender) {
-        case 0:
-            point.x -= 1;
-            point.z += 1;
-            break;
-        case 1:
-            point.x -= 1;
-            point.z -= 1;
-            break;
-        case 2:
-            point.x += 1;
-            point.z -= 1;
-            break;
-        case 3:
-            point.x += 1;
-            point.z += 1;
-            break;
+            case 0:
+                point.x -= 1;
+                point.z += 1;
+                break;
+            case 1:
+                point.x -= 1;
+                point.z -= 1;
+                break;
+            case 2:
+                point.x += 1;
+                point.z -= 1;
+                break;
+            case 3:
+                point.x += 1;
+                point.z += 1;
+                break;
         }
     }
 
@@ -127,23 +127,119 @@ public class ClientProxy extends CommonProxy {
             position.z = (int) Math.floor(playerPosition.z);
 
             switch (rotationRender) {
-            case 0:
-                position.x -= schematic.getWidth();
-                position.z += 1;
-                break;
-            case 1:
-                position.x -= schematic.getWidth();
-                position.z -= schematic.getLength();
-                break;
-            case 2:
-                position.x += 1;
-                position.z -= schematic.getLength();
-                break;
-            case 3:
-                position.x += 1;
-                position.z += 1;
-                break;
+                case 0:
+                    position.x -= schematic.getWidth();
+                    position.z += 1;
+                    break;
+                case 1:
+                    position.x -= schematic.getWidth();
+                    position.z -= schematic.getLength();
+                    break;
+                case 2:
+                    position.x += 1;
+                    position.z -= schematic.getLength();
+                    break;
+                case 3:
+                    position.x += 1;
+                    position.z += 1;
+                    break;
             }
+        }
+    }
+
+    public static void moveSchematic(SchematicWorld schematic, Integer x, Integer y, Integer z) {
+        if (schematic != null) {
+            Vector3i position = schematic.position;
+            position.x = x;
+            position.y = y;
+            position.z = z;
+        }
+    }
+
+    public static Map<String, Map<String, Map<String, Integer>>> openCoordinatesFile() throws ClassCastException, IOException {
+        Gson gson = new Gson();
+        File coordinatesFile = new File(ConfigurationHandler.schematicDirectory, Constants.Files.Coordinates + ".json");
+        Map<String, Map<String, Map<String, Integer>>> coordinates = new HashMap<>();
+        if (coordinatesFile.exists() && coordinatesFile.canRead() && coordinatesFile.canWrite()) {
+            try (Reader reader = Files.newBufferedReader(new File(ConfigurationHandler.schematicDirectory, Constants.Files.Coordinates + ".json").toPath())) {
+                //Map<?,?> test = gson.fromJson(reader, Map.class);
+                coordinates = gson.fromJson(reader, new TypeToken<Map<String, Map<String, Map<String, Integer>>>>() {
+                }.getType());
+            } catch (Exception e) {
+                throw new ClassCastException("Failed to convert json file to Map<String,Map<String,Integer>>");
+            }
+
+        } else if (!coordinatesFile.exists()) {
+            if (saveCoordinatesFile(coordinates)) {
+                Reference.logger.info("Created new coordinates file");
+            } else throw new IOException("Failed to create coordinates file");
+        } else {
+            throw new IOException("No read/write permission for coordinates file");
+        }
+        return coordinates;
+    }
+
+    public static boolean saveCoordinatesFile(Map<String, Map<String, Map<String, Integer>>> map) {
+        Gson gsonBuilder = new GsonBuilder().setPrettyPrinting().create();
+        File coordinatesFile = new File(ConfigurationHandler.schematicDirectory, Constants.Files.Coordinates + ".json");
+        try (FileWriter writer = new FileWriter(coordinatesFile.getAbsoluteFile())) {
+            gsonBuilder.toJson(map, new TypeToken<Map<String, Map<String, Map<String, Integer>>>>() {
+            }.getType(), writer);
+            writer.flush();
+            Reference.logger.info("Successfully written to coordinates file");
+            return true;
+        } catch (IOException e) {
+            Reference.logger.info("Failed to write to coordinates file");
+            return false;
+        }
+    }
+
+    public static boolean addCoordinates(String worldServerName, String schematicName, Integer X, Integer Y, Integer Z) {
+        try {
+            Map<String, Map<String, Map<String, Integer>>> coordinates = openCoordinatesFile();
+            if (coordinates.containsKey(worldServerName)) {
+                coordinates.get(worldServerName).put(schematicName, new HashMap<String, Integer>() {{
+                    put("X", X);
+                    put("Y", Y);
+                    put("Z", Z);
+                }});
+            } else {
+                coordinates.put(worldServerName, new HashMap<String, Map<String, Integer>>() {{
+                    put(schematicName, new HashMap<String, Integer>() {{
+                        put("X", X);
+                        put("Y", Y);
+                        put("Z", Z);
+                    }});
+                }});
+            }
+            saveCoordinatesFile(coordinates);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * gets the coordinates if present
+     *
+     * @return {@link ImmutablePair} with bool (true if coordinates found, false if not) and {@link ImmutableTriple} storing X,Y,Z {@link Integer}
+     */
+    public static ImmutablePair<Boolean, ImmutableTriple<Integer, Integer, Integer>> getCoordinates(String worldServerName, String schematicName) {
+        try {
+            Map<String, Map<String, Map<String, Integer>>> coordinates = openCoordinatesFile();
+            if (coordinates.containsKey(worldServerName)) {
+                Map<String, Map<String, Integer>> schematicMap = coordinates.get(worldServerName);
+                if (schematicMap.containsKey(schematicName)) {
+                    Map<String, Integer> coordinateMap = schematicMap.get(schematicName);
+                    if (coordinateMap.containsKey("X") && coordinateMap.containsKey("Y") && coordinateMap.containsKey("Z")) {
+                        return new ImmutablePair<>(true, new ImmutableTriple<>(coordinateMap.get("X"), coordinateMap.get("Y"), coordinateMap.get("Z")));
+                    }
+                }
+            }
+            return new ImmutablePair<>(false, null);
+        } catch (Exception e) {
+
+            return new ImmutablePair<>(false, null);
         }
     }
 
@@ -151,12 +247,7 @@ public class ClientProxy extends CommonProxy {
     public void preInit(FMLPreInitializationEvent event) {
         super.preInit(event);
 
-        final Property[] sliders = {
-                ConfigurationHandler.propAlpha,
-                ConfigurationHandler.propBlockDelta,
-                ConfigurationHandler.propPlaceDelay,
-                ConfigurationHandler.propTimeout
-        };
+        final Property[] sliders = {ConfigurationHandler.propAlpha, ConfigurationHandler.propBlockDelta, ConfigurationHandler.propPlaceDelay, ConfigurationHandler.propTimeout};
         for (Property prop : sliders) {
             prop.setConfigEntryClass(GuiConfigEntries.NumberSliderEntry.class);
         }
@@ -224,7 +315,7 @@ public class ClientProxy extends CommonProxy {
             return false;
         }
 
-        SchematicWorld world = new SchematicWorld(schematic,filename);
+        SchematicWorld world = new SchematicWorld(schematic, filename);
 
         Reference.logger.debug("Loaded {} [w:{},h:{},l:{}]", filename, world.getWidth(), world.getHeight(), world.getLength());
 

--- a/src/main/java/com/github/lunatrius/schematica/reference/Constants.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Constants.java
@@ -39,4 +39,9 @@ public final class Constants {
         public static final int MINIMUM_COORD = -30000000;
         public static final int MAXIMUM_COORD = +30000000;
     }
+
+    public static final class Files {
+        //+ .json
+        public static final String Coordinates = "Coordinates";
+    }
 }

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -148,24 +148,6 @@ public final class Names {
         }
 
         public static final class Control {
-            /*
-            Should be in this category, not Save as coordinates are not stored within the schematic.
-            Instead, in the Schematics folder a json file will be present which stores the coordinates in the following way:
-            {
-                "server name or world name" : {
-                        "schematic name 1" : {
-                            "x" : 0,
-                            "y" : 0,
-                            "z" : 0
-                        },
-                        "schematic name 2" : {
-                            "x" : 0,
-                            "y" : 0,
-                            "z" : 0
-                        }
-                }
-            }
-            */
             public static final String SAVE_COORDINATES = "schematica.gui.savecoordinates";
             public static final String MOVE_SCHEMATIC = "schematica.gui.moveschematic";
             public static final String MATERIALS = "schematica.gui.materials";

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -71,6 +71,10 @@ public final class Names {
 
         public static final String LANG_PREFIX = Reference.MODID.toLowerCase() + ".config";
     }
+        public static final class Chat {
+            public static final String SAVE_COORDINATES_SUCCESS = "Schematica.chat.saveCoordinatesSuccess";
+            public static final String SAVE_COORDINATES_FAIL = "Schematica.chat.saveCoordinatesFail";
+        }
 
     public static final class Command {
         public static final class Save {

--- a/src/main/java/com/github/lunatrius/schematica/reference/Names.java
+++ b/src/main/java/com/github/lunatrius/schematica/reference/Names.java
@@ -140,9 +140,29 @@ public final class Names {
             public static final String POINT_BLUE = "schematica.gui.point.blue";
             public static final String SAVE = "schematica.gui.save";
             public static final String SAVE_SELECTION = "schematica.gui.saveselection";
+
         }
 
         public static final class Control {
+            /*
+            Should be in this category, not Save as coordinates are not stored within the schematic.
+            Instead, in the Schematics folder a json file will be present which stores the coordinates in the following way:
+            {
+                "server name or world name" : {
+                        "schematic name 1" : {
+                            "x" : 0,
+                            "y" : 0,
+                            "z" : 0
+                        },
+                        "schematic name 2" : {
+                            "x" : 0,
+                            "y" : 0,
+                            "z" : 0
+                        }
+                }
+            }
+            */
+            public static final String SAVE_COORDINATES = "schematica.gui.savecoordinates";
             public static final String MOVE_SCHEMATIC = "schematica.gui.moveschematic";
             public static final String MATERIALS = "schematica.gui.materials";
             public static final String PRINTER = "schematica.gui.printer";

--- a/src/main/resources/assets/schematica/lang/en_US.lang
+++ b/src/main/resources/assets/schematica/lang/en_US.lang
@@ -13,6 +13,7 @@ schematica.gui.movehere=Move here
 schematica.gui.flip=Flip
 schematica.gui.rotate=Rotate
 schematica.gui.save=Save
+schematica.gui.savecoordinates=Save Coordinates
 schematica.gui.moveschematic=Move schematic
 schematica.gui.layers=Layers
 schematica.gui.operations=Operations

--- a/src/main/resources/assets/schematica/lang/en_US.lang
+++ b/src/main/resources/assets/schematica/lang/en_US.lang
@@ -108,6 +108,10 @@ schematica.config.schematicDirectory.tooltip=Schematic directory.
 schematica.config.extraAirBlocks=Extra Air Blocks
 schematica.config.extraAirBlocks.tooltip=Extra blocks to consider as air for the schematic renderer.
 
+# chat
+Schematica.chat.saveCoordinatesSuccess=Successfully saved coordinates
+Schematica.chat.saveCoordinatesFail=Failed to save coordinates
+
 # gui - config - server
 schematica.config.printerEnabled=Allow Printer
 schematica.config.printerEnabled.tooltip=Allow players to use the printer.

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,7 +5,7 @@
 	"version": "${modVersion}",
 	"mcversion": "${minecraftVersion}",
 	"authorList": ["Lunatrius"],
-	"credits": "AbrarSyed, AtomicBlom, UltraMoogleMan",
+	"credits": "AbrarSyed, AtomicBlom, bombcar, Kamesuta, Kiwi233, Mist475, Johann Bernhardt , UltraMoogleMan",
 	"dependants": [  ],
 	"dependencies": [ "LunatriusCore@[1.1.5,)" ],
 	"parent": "",


### PR DESCRIPTION
With this pr it's possible to save the coordinates of schematics per world/server. It stores these in a json file in the following structure:
"server name in server list/ world name in singleplayer" : {
""schematic name" : {
"X":0,
"Y":0,
"Z":0
}
}
When loading a schematic with saved coordinates the game will set the coordinates to the found coordinates. Otherwise the default behaviour will take place