### PR TITLE
Add support for architecturecraft block state printing

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,4 +3,5 @@
 dependencies {
 	implementation('com.github.GTNewHorizons:LunatriusCore:1.2.1-GTNH:dev')
     compileOnly rfg.deobf('curse.maven:lotr-423748:4091561')
+    compileOnly('com.github.GTNewHorizons:ArchitectureCraft:1.12.10-feat-set-orientation.1+a970489b85:dev')
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,6 +1,7 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
+	mavenLocal()
 	maven {
 		name 'GTNH Maven'
 		url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'

--- a/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
@@ -14,6 +14,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.client.C0BPacketEntityAction;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -27,6 +28,7 @@ import com.github.lunatrius.schematica.client.printer.registry.PlacementData;
 import com.github.lunatrius.schematica.client.printer.registry.PlacementRegistry;
 import com.github.lunatrius.schematica.client.util.BlockToItemStack;
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
+import com.github.lunatrius.schematica.compat.architecturecraft.ArchitectureCraftHelper;
 import com.github.lunatrius.schematica.handler.ConfigurationHandler;
 import com.github.lunatrius.schematica.proxy.ClientProxy;
 import com.github.lunatrius.schematica.reference.Constants;
@@ -44,6 +46,7 @@ public class SchematicPrinter {
 
     private boolean isEnabled;
     private boolean isPrinting;
+    private boolean currentBlockIsACShape;
 
     private SchematicWorld schematic = null;
     private byte[][][] timeout = null;
@@ -178,8 +181,18 @@ public class SchematicPrinter {
             return false;
         }
 
+        this.currentBlockIsACShape = ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(block);
+
         if (placeBlock(world, player, wx, wy, wz, block, metadata, itemStack)) {
             this.timeout[x][y][z] = (byte) ConfigurationHandler.timeout;
+
+            if (this.currentBlockIsACShape) {
+                TileEntity schematicTE = this.schematic.getTileEntity(x, y, z);
+                if (schematicTE != null) {
+                    byte[] orientation = ArchitectureCraftHelper.getOrientationFromTE(schematicTE);
+                    ArchitectureCraftHelper.sendOrientationUpdate(wx, wy, wz, orientation[0], orientation[1]);
+                }
+            }
 
             if (!ConfigurationHandler.placeInstantly) {
                 return true;
@@ -404,6 +417,10 @@ public class SchematicPrinter {
     private int getInventorySlotWithItem(final InventoryPlayer inventory, final ItemStack itemStack) {
         for (int i = 0; i < inventory.mainInventory.length; i++) {
             if (inventory.mainInventory[i] != null && inventory.mainInventory[i].isItemEqual(itemStack)) {
+                if (this.currentBlockIsACShape
+                    && !ArchitectureCraftHelper.areShapeItemStacksEqual(itemStack, inventory.mainInventory[i])) {
+                    continue;
+                }
                 return i;
             }
         }

--- a/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
@@ -241,6 +241,8 @@ public class SchematicPrinter {
 
     private boolean placeBlock(World world, EntityPlayer player, int x, int y, int z, Block block, int metadata,
         ItemStack itemStack) {
+        this.currentBlockIsACShape = ArchitectureCraftHelper.isShapeBlock(block);
+
         if (isBlacklisted(block, itemStack)) {
             return false;
         }

--- a/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/printer/SchematicPrinter.java
@@ -181,12 +181,10 @@ public class SchematicPrinter {
             return false;
         }
 
-        this.currentBlockIsACShape = ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(block);
-
         if (placeBlock(world, player, wx, wy, wz, block, metadata, itemStack)) {
             this.timeout[x][y][z] = (byte) ConfigurationHandler.timeout;
 
-            if (this.currentBlockIsACShape) {
+            if (ArchitectureCraftHelper.isShapeBlock(block)) {
                 TileEntity schematicTE = this.schematic.getTileEntity(x, y, z);
                 if (schematicTE != null) {
                     byte[] orientation = ArchitectureCraftHelper.getOrientationFromTE(schematicTE);

--- a/src/main/java/com/github/lunatrius/schematica/client/util/BlockList.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/BlockList.java
@@ -12,6 +12,7 @@ import net.minecraft.util.MovingObjectPosition;
 
 import com.github.lunatrius.core.entity.EntityHelper;
 import com.github.lunatrius.schematica.client.world.SchematicWorld;
+import com.github.lunatrius.schematica.compat.architecturecraft.ArchitectureCraftHelper;
 import com.github.lunatrius.schematica.reference.Reference;
 
 public class BlockList {
@@ -59,7 +60,12 @@ public class BlockList {
                         continue;
                     }
 
-                    final WrappedItemStack wrappedItemStack = findOrCreateWrappedItemStackFor(blockList, stack);
+                    final boolean isACShape = ArchitectureCraftHelper.isLoaded()
+                        && ArchitectureCraftHelper.isShapeBlock(block);
+                    final WrappedItemStack wrappedItemStack = findOrCreateWrappedItemStackFor(
+                        blockList,
+                        stack,
+                        isACShape);
                     if (isPlaced) {
                         wrappedItemStack.placed++;
                     }
@@ -69,25 +75,35 @@ public class BlockList {
         }
 
         for (WrappedItemStack wrappedItemStack : blockList) {
-            if (player.capabilities.isCreativeMode) wrappedItemStack.inventory = -1;
-            else wrappedItemStack.inventory = EntityHelper.getItemCountInInventory(
-                player.inventory,
-                wrappedItemStack.itemStack.getItem(),
-                wrappedItemStack.itemStack.getItemDamage());
+            if (player.capabilities.isCreativeMode) {
+                wrappedItemStack.inventory = -1;
+            } else if (wrappedItemStack.isACShape) {
+                wrappedItemStack.inventory = ArchitectureCraftHelper
+                    .countShapeInInventory(player.inventory, wrappedItemStack.itemStack);
+            } else {
+                wrappedItemStack.inventory = EntityHelper.getItemCountInInventory(
+                    player.inventory,
+                    wrappedItemStack.itemStack.getItem(),
+                    wrappedItemStack.itemStack.getItemDamage());
+            }
         }
 
         return blockList;
     }
 
     private WrappedItemStack findOrCreateWrappedItemStackFor(final List<WrappedItemStack> blockList,
-        final ItemStack itemStack) {
+        final ItemStack itemStack, final boolean isACShape) {
         for (final WrappedItemStack wrappedItemStack : blockList) {
             if (wrappedItemStack.itemStack.isItemEqual(itemStack)) {
+                if (isACShape
+                    && !ArchitectureCraftHelper.areShapeItemStacksEqual(wrappedItemStack.itemStack, itemStack)) {
+                    continue;
+                }
                 return wrappedItemStack;
             }
         }
 
-        final WrappedItemStack wrappedItemStack = new WrappedItemStack(itemStack.copy());
+        final WrappedItemStack wrappedItemStack = new WrappedItemStack(itemStack.copy(), isACShape);
         blockList.add(wrappedItemStack);
         return wrappedItemStack;
     }
@@ -98,9 +114,15 @@ public class BlockList {
         public int placed;
         public int total;
         public int inventory;
+        public boolean isACShape;
 
         public WrappedItemStack(final ItemStack itemStack) {
+            this(itemStack, false);
+        }
+
+        public WrappedItemStack(final ItemStack itemStack, final boolean isACShape) {
             this(itemStack, 0, 0);
+            this.isACShape = isACShape;
         }
 
         public WrappedItemStack(final ItemStack itemStack, final int placed, final int total) {

--- a/src/main/java/com/github/lunatrius/schematica/client/util/BlockList.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/util/BlockList.java
@@ -60,8 +60,7 @@ public class BlockList {
                         continue;
                     }
 
-                    final boolean isACShape = ArchitectureCraftHelper.isLoaded()
-                        && ArchitectureCraftHelper.isShapeBlock(block);
+                    final boolean isACShape = ArchitectureCraftHelper.isShapeBlock(block);
                     final WrappedItemStack wrappedItemStack = findOrCreateWrappedItemStackFor(
                         blockList,
                         stack,

--- a/src/main/java/com/github/lunatrius/schematica/client/world/SchematicWorld.java
+++ b/src/main/java/com/github/lunatrius/schematica/client/world/SchematicWorld.java
@@ -21,6 +21,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.github.lunatrius.core.util.vector.Vector3f;
 import com.github.lunatrius.core.util.vector.Vector3i;
 import com.github.lunatrius.schematica.api.ISchematic;
+import com.github.lunatrius.schematica.compat.architecturecraft.ArchitectureCraftHelper;
 import com.github.lunatrius.schematica.handler.ConfigurationHandler;
 import com.github.lunatrius.schematica.reference.Reference;
 import com.github.lunatrius.schematica.world.chunk.ChunkProviderSchematic;
@@ -252,6 +253,12 @@ public class SchematicWorld extends World {
                     tileEntity.xCoord = width - 1 - tileEntity.xCoord;
                     tileEntity.blockMetadata = schematicFlipped
                         .getBlockMetadata(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+                    if (ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(
+                        schematicFlipped.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord))) {
+                        byte[] ori = ArchitectureCraftHelper.getOrientationFromTE(tileEntity);
+                        byte[] newOri = ArchitectureCraftHelper.transformOrientationFlip(ori[0], ori[1], direction);
+                        ArchitectureCraftHelper.setOrientationOnTE(tileEntity, newOri[0], newOri[1]);
+                    }
                     schematicFlipped.setTileEntity(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, tileEntity);
                 }
                 flipStateX++;
@@ -274,6 +281,12 @@ public class SchematicWorld extends World {
                     tileEntity.zCoord = length - 1 - tileEntity.zCoord;
                     tileEntity.blockMetadata = schematicFlipped
                         .getBlockMetadata(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+                    if (ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(
+                        schematicFlipped.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord))) {
+                        byte[] ori = ArchitectureCraftHelper.getOrientationFromTE(tileEntity);
+                        byte[] newOri = ArchitectureCraftHelper.transformOrientationFlip(ori[0], ori[1], direction);
+                        ArchitectureCraftHelper.setOrientationOnTE(tileEntity, newOri[0], newOri[1]);
+                    }
                     schematicFlipped.setTileEntity(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, tileEntity);
                 }
                 flipStateZ++;
@@ -297,6 +310,12 @@ public class SchematicWorld extends World {
                     tileEntity.yCoord = height - 1 - tileEntity.yCoord;
                     tileEntity.blockMetadata = schematicFlipped
                         .getBlockMetadata(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+                    if (ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(
+                        schematicFlipped.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord))) {
+                        byte[] ori = ArchitectureCraftHelper.getOrientationFromTE(tileEntity);
+                        byte[] newOri = ArchitectureCraftHelper.transformOrientationFlip(ori[0], ori[1], direction);
+                        ArchitectureCraftHelper.setOrientationOnTE(tileEntity, newOri[0], newOri[1]);
+                    }
                     schematicFlipped.setTileEntity(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, tileEntity);
                 }
                 flipStateY++;
@@ -346,6 +365,12 @@ public class SchematicWorld extends World {
                     tileEntity.zCoord = height - 1 - coord;
                     tileEntity.blockMetadata = schematicRotated
                         .getBlockMetadata(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+                    if (ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(
+                        schematicRotated.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord))) {
+                        byte[] ori = ArchitectureCraftHelper.getOrientationFromTE(tileEntity);
+                        byte[] newOri = ArchitectureCraftHelper.transformOrientationRotate(ori[0], ori[1], direction);
+                        ArchitectureCraftHelper.setOrientationOnTE(tileEntity, newOri[0], newOri[1]);
+                    }
                     schematicRotated.setTileEntity(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, tileEntity);
                 }
 
@@ -389,6 +414,13 @@ public class SchematicWorld extends World {
                         skullTileEntity.func_145903_a((skullTileEntity.func_145906_b() + 12) & 15);
                     }
 
+                    if (ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(
+                        schematicRotated.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord))) {
+                        byte[] ori = ArchitectureCraftHelper.getOrientationFromTE(tileEntity);
+                        byte[] newOri = ArchitectureCraftHelper.transformOrientationRotate(ori[0], ori[1], direction);
+                        ArchitectureCraftHelper.setOrientationOnTE(tileEntity, newOri[0], newOri[1]);
+                    }
+
                     schematicRotated.setTileEntity(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, tileEntity);
                 }
 
@@ -426,6 +458,12 @@ public class SchematicWorld extends World {
                     tileEntity.yCoord = width - 1 - coord;
                     tileEntity.blockMetadata = schematicRotated
                         .getBlockMetadata(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord);
+                    if (ArchitectureCraftHelper.isLoaded() && ArchitectureCraftHelper.isShapeBlock(
+                        schematicRotated.getBlock(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord))) {
+                        byte[] ori = ArchitectureCraftHelper.getOrientationFromTE(tileEntity);
+                        byte[] newOri = ArchitectureCraftHelper.transformOrientationRotate(ori[0], ori[1], direction);
+                        ArchitectureCraftHelper.setOrientationOnTE(tileEntity, newOri[0], newOri[1]);
+                    }
                     schematicRotated.setTileEntity(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, tileEntity);
                 }
 

--- a/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftBridge.java
+++ b/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftBridge.java
@@ -1,0 +1,20 @@
+package com.github.lunatrius.schematica.compat.architecturecraft;
+
+import gcewing.architecture.ArchitectureCraft;
+import gcewing.architecture.common.network.ChannelOutput;
+
+/**
+ * Isolates direct ArchitectureCraft class references. Do not use without checking if ArchitectureCraft is loaded.
+ */
+class ArchitectureCraftBridge {
+
+    static void sendOrientationUpdate(int x, int y, int z, byte side, byte turn) {
+        ChannelOutput out = ArchitectureCraft.channel.openServer("SetOrientation");
+        out.writeInt(x);
+        out.writeInt(y);
+        out.writeInt(z);
+        out.writeByte(side);
+        out.writeByte(turn);
+        out.close();
+    }
+}

--- a/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
@@ -1,0 +1,109 @@
+package com.github.lunatrius.schematica.compat.architecturecraft;
+
+import java.io.DataOutput;
+import java.lang.reflect.Method;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+import com.github.lunatrius.schematica.reference.Reference;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.registry.GameData;
+
+public class ArchitectureCraftHelper {
+
+    private static final String MOD_ID = "ArchitectureCraft";
+    private static Boolean loaded = null;
+
+    public static boolean isLoaded() {
+        if (loaded == null) {
+            loaded = Loader.isModLoaded(MOD_ID);
+        }
+        return loaded;
+    }
+
+    public static boolean isShapeBlock(Block block) {
+        if (!isLoaded()) return false;
+        String name = GameData.getBlockRegistry()
+            .getNameForObject(block);
+        return "ArchitectureCraft:shape".equals(name) || "ArchitectureCraft:shapeSE".equals(name);
+    }
+
+    /**
+     * Compare two AC shape item stacks by their shape-defining NBT tags (Shape ID, base material).
+     * Both stacks must already pass isItemEqual (same Item + damage).
+     */
+    public static boolean areShapeItemStacksEqual(ItemStack a, ItemStack b) {
+        NBTTagCompound tagA = a.getTagCompound();
+        NBTTagCompound tagB = b.getTagCompound();
+
+        if (tagA == null && tagB == null) return true;
+        if (tagA == null || tagB == null) return false;
+
+        if (tagA.getInteger("Shape") != tagB.getInteger("Shape")) return false;
+
+        String baseNameA = tagA.getString("BaseName");
+        String baseNameB = tagB.getString("BaseName");
+        if (!baseNameA.equals(baseNameB)) return false;
+
+        if (tagA.getInteger("BaseData") != tagB.getInteger("BaseData")) return false;
+
+        return true;
+    }
+
+    /**
+     * Read orientation (side, turn) from a tile entity's NBT.
+     * Returns a 2-element byte array: [side, turn].
+     */
+    public static byte[] getOrientationFromTE(TileEntity te) {
+        NBTTagCompound nbt = new NBTTagCompound();
+        te.writeToNBT(nbt);
+        return new byte[] { nbt.getByte("side"), nbt.getByte("turn") };
+    }
+
+    /**
+     * Count items in inventory that match the given AC shape item stack by NBT (Shape, BaseName, BaseData).
+     */
+    public static int countShapeInInventory(IInventory inventory, ItemStack target) {
+        int count = 0;
+        for (int i = 0; i < inventory.getSizeInventory(); i++) {
+            ItemStack slot = inventory.getStackInSlot(i);
+            if (slot != null && slot.isItemEqual(target) && areShapeItemStacksEqual(target, slot)) {
+                count += slot.stackSize;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Send a SetOrientation message to the server via ArchitectureCraft's DataChannel.
+     * Uses reflection to avoid a compile-time dependency on ArchitectureCraft.
+     */
+    public static void sendOrientationUpdate(int x, int y, int z, byte side, byte turn) {
+        try {
+            Class<?> acClass = Class.forName("gcewing.architecture.ArchitectureCraft");
+            Object channel = acClass.getField("channel")
+                .get(null);
+            Method openServer = channel.getClass()
+                .getMethod("openServer", String.class);
+            Object out = openServer.invoke(channel, "SetOrientation");
+
+            DataOutput dataOut = (DataOutput) out;
+            dataOut.writeInt(x);
+            dataOut.writeInt(y);
+            dataOut.writeInt(z);
+            dataOut.writeByte(side);
+            dataOut.writeByte(turn);
+
+            out.getClass()
+                .getMethod("close")
+                .invoke(out);
+        } catch (Exception e) {
+            Reference.logger.error("Failed to send AC orientation update", e);
+        }
+    }
+}

--- a/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
@@ -81,7 +81,6 @@ public class ArchitectureCraftHelper {
 
     /**
      * Send a SetOrientation message to the server via ArchitectureCraft's DataChannel.
-     * Uses reflection to avoid a compile-time dependency on ArchitectureCraft.
      */
     public static void sendOrientationUpdate(int x, int y, int z, byte side, byte turn) {
         try {
@@ -99,8 +98,8 @@ public class ArchitectureCraftHelper {
             dataOut.writeByte(side);
             dataOut.writeByte(turn);
 
-            out.getClass()
-                .getMethod("close")
+            Class<?> channelOutputClass = Class.forName("gcewing.architecture.common.network.ChannelOutput");
+            channelOutputClass.getMethod("close")
                 .invoke(out);
         } catch (Exception e) {
             Reference.logger.error("Failed to send AC orientation update", e);

--- a/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
@@ -5,6 +5,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameData;
@@ -72,6 +73,106 @@ public class ArchitectureCraftHelper {
             }
         }
         return count;
+    }
+
+    /**
+     * Update side/turn in a tile entity's NBT via writeToNBT/readFromNBT round-trip.
+     */
+    public static void setOrientationOnTE(TileEntity te, byte side, byte turn) {
+        NBTTagCompound nbt = new NBTTagCompound();
+        te.writeToNBT(nbt);
+        nbt.setByte("side", side);
+        nbt.setByte("turn", turn);
+        te.readFromNBT(nbt);
+    }
+
+    // @formatter:off
+    // Rotation lookup tables: sideMap[oldSide] = newSide, turnDelta[oldSide] = delta
+    // newTurn = (oldTurn + turnDelta) % 4
+    // Derived from Matrix3.sideRotations and turnRotations in ArchitectureCraft.
+
+    // Rotate 90 CW around Y (ForgeDirection.UP)
+    private static final int[] ROTATE_Y_SIDE  = { 0, 1, 5, 4, 2, 3 };
+    private static final int[] ROTATE_Y_DELTA = { 3, 1, 0, 0, 0, 0 };
+
+    // Rotate 90 CW around X (ForgeDirection.EAST)
+    private static final int[] ROTATE_X_SIDE  = { 3, 2, 0, 1, 4, 5 };
+    private static final int[] ROTATE_X_DELTA = { 2, 0, 0, 2, 3, 1 };
+
+    // Rotate 90 CW around Z (ForgeDirection.SOUTH)
+    private static final int[] ROTATE_Z_SIDE  = { 4, 5, 2, 3, 1, 0 };
+    private static final int[] ROTATE_Z_DELTA = { 3, 3, 3, 1, 3, 3 };
+
+    // Flip lookup tables: sideMap[oldSide] = newSide
+    // Turn formulas vary per flip axis and sometimes per side.
+
+    // Flip X (ForgeDirection.EAST): WEST<->EAST
+    private static final int[] FLIP_X_SIDE = { 0, 1, 2, 3, 5, 4 };
+
+    // Flip Y (ForgeDirection.UP): DOWN<->UP
+    private static final int[] FLIP_Y_SIDE = { 1, 0, 2, 3, 4, 5 };
+
+    // Flip Z (ForgeDirection.SOUTH): NORTH<->SOUTH
+    private static final int[] FLIP_Z_SIDE = { 0, 1, 3, 2, 4, 5 };
+    // @formatter:on
+
+    /**
+     * Transform AC orientation for a schematic rotation (90 CW around the given axis).
+     * Returns [newSide, newTurn].
+     */
+    public static byte[] transformOrientationRotate(byte side, byte turn, ForgeDirection axis) {
+        if (side < 0 || side > 5 || turn < 0 || turn > 3) return new byte[] { side, turn };
+        final int[] sideMap;
+        final int[] turnDelta;
+        switch (axis) {
+            case UP:
+                sideMap = ROTATE_Y_SIDE;
+                turnDelta = ROTATE_Y_DELTA;
+                break;
+            case EAST:
+                sideMap = ROTATE_X_SIDE;
+                turnDelta = ROTATE_X_DELTA;
+                break;
+            case SOUTH:
+                sideMap = ROTATE_Z_SIDE;
+                turnDelta = ROTATE_Z_DELTA;
+                break;
+            default:
+                return new byte[] { side, turn };
+        }
+        return new byte[] { (byte) sideMap[side], (byte) ((turn + turnDelta[side]) % 4) };
+    }
+
+    /**
+     * Transform AC orientation for a schematic flip (mirror along the given axis).
+     * Exact for bilaterally symmetric shapes; best-fit approximation for asymmetric shapes.
+     * Returns [newSide, newTurn].
+     */
+    public static byte[] transformOrientationFlip(byte side, byte turn, ForgeDirection axis) {
+        if (side < 0 || side > 5 || turn < 0 || turn > 3) return new byte[] { side, turn };
+        final int newSide;
+        final int newTurn;
+        switch (axis) {
+            case EAST: // Flip X
+                newSide = FLIP_X_SIDE[side];
+                newTurn = (4 - turn) % 4;
+                break;
+            case UP: // Flip Y
+                newSide = FLIP_Y_SIDE[side];
+                newTurn = (6 - turn) % 4;
+                break;
+            case SOUTH: // Flip Z
+                newSide = FLIP_Z_SIDE[side];
+                if (side <= 1) {
+                    newTurn = (6 - turn) % 4;
+                } else {
+                    newTurn = (4 - turn) % 4;
+                }
+                break;
+            default:
+                return new byte[] { side, turn };
+        }
+        return new byte[] { (byte) newSide, (byte) newTurn };
     }
 
     /**

--- a/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
+++ b/src/main/java/com/github/lunatrius/schematica/compat/architecturecraft/ArchitectureCraftHelper.java
@@ -1,15 +1,10 @@
 package com.github.lunatrius.schematica.compat.architecturecraft;
 
-import java.io.DataOutput;
-import java.lang.reflect.Method;
-
 import net.minecraft.block.Block;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-
-import com.github.lunatrius.schematica.reference.Reference;
 
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameData;
@@ -80,29 +75,9 @@ public class ArchitectureCraftHelper {
     }
 
     /**
-     * Send a SetOrientation message to the server via ArchitectureCraft's DataChannel.
+     * Fix block orientation via ArchitectureCraft's DataChannel.
      */
     public static void sendOrientationUpdate(int x, int y, int z, byte side, byte turn) {
-        try {
-            Class<?> acClass = Class.forName("gcewing.architecture.ArchitectureCraft");
-            Object channel = acClass.getField("channel")
-                .get(null);
-            Method openServer = channel.getClass()
-                .getMethod("openServer", String.class);
-            Object out = openServer.invoke(channel, "SetOrientation");
-
-            DataOutput dataOut = (DataOutput) out;
-            dataOut.writeInt(x);
-            dataOut.writeInt(y);
-            dataOut.writeInt(z);
-            dataOut.writeByte(side);
-            dataOut.writeByte(turn);
-
-            Class<?> channelOutputClass = Class.forName("gcewing.architecture.common.network.ChannelOutput");
-            channelOutputClass.getMethod("close")
-                .invoke(out);
-        } catch (Exception e) {
-            Reference.logger.error("Failed to send AC orientation update", e);
-        }
+        ArchitectureCraftBridge.sendOrientationUpdate(x, y, z, side, turn);
     }
 }


### PR DESCRIPTION
Adds the ability to differentiate between different Architecturecraft block cuts, and orient them correctly during printing.

Depends on a separate update to Architecturecraft, which adds a `SetOrientation` message for Schematica to use after placing the Architecturecraft block, in order to correct its orientation. The PR for the Architecturecraft update is here: https://github.com/GTNewHorizons/ArchitectureCraft/pull/35


Before/After:
<img width="1149" height="956" alt="image" src="https://github.com/user-attachments/assets/140c955b-f20d-4cdf-b272-d47973bc97c5" />
